### PR TITLE
Adopt the new `AsyncQueue`, remove dependency on all three Fluent drivers, other cleanup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,101 @@ on:
   push: { branches: [ main ] }
 
 jobs:
-  unit-tests:
-    uses: vapor/ci/.github/workflows/run-unit-tests.yml@main
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  api-breakage:
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    container: swift:noble
+    timeout-minutes: 30
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with: { 'fetch-depth': 0 }
+      - name: Run API breakage check
+        run: |
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+          swift package diagnose-api-breaking-changes origin/main
+  
+  linux-unit:
+    if: ${{ !(github.event.pull_request.draft || false) }}
+    strategy:
+      fail-fast: false
+      matrix:
+        swift-image:
+          - swift:5.8-jammy
+          - swift:5.9-jammy
+          - swift:5.10-noble
+          - swiftlang/swift:nightly-6.0-jammy
+          - swiftlang/swift:nightly-main-jammy
+        include:
+          - sanitize: '--sanitize=thread'
+          - swift-image: swift:5.8-jammy
+            sanitize: ''
+    runs-on: ubuntu-latest
+    container: ${{ matrix.swift-image }}
+    services:
+      psql: { image: 'postgres:16', env: { POSTGRES_USER: test_username, POSTGRES_PASSWORD: test_password, POSTGRES_DB: test_database, POSTGRES_HOST_AUTH_METHOD: scram-sha-256, POSTGRES_INITDB_ARGS: --auth-host=scram-sha-256 } }
+      mysql: { image: 'mysql:8', env: { MYSQL_ALLOW_EMPTY_PASSWORD: true, MYSQL_USER: test_username, MYSQL_PASSWORD: test_password, MYSQL_DATABASE: test_database } }
+    timeout-minutes: 60
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Run unit tests
+        env:
+          SANITIZE: ${{ matrix.sanitize }}
+          POSTGRES_HOST: psql
+          MYSQL_HOST: mysql
+        run: SWIFT_DETERMINISTIC_HASHING=1 swift test ${SANITIZE} --enable-code-coverage
+      - name: Upload coverage data
+        uses: vapor/swift-codecov-action@v0.3
+        with:
+          codecov_token: ${{ secrets.CODECOV_TOKEN || '' }}
+
+  macos-unit:
+    if: ${{ !(github.event.pull_request.draft || false) }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - macos-version: macos-13
+            xcode-version: '~15.2'
+          - macos-version: macos-14
+            xcode-version: latest-stable
+    runs-on: ${{ matrix.macos-version }}
+    timeout-minutes: 60
+    steps:
+      - name: Select appropriate Xcode version
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ matrix.xcode-version }}
+      - name: Install and setup Postgres
+        run: |
+          export PATH="$(brew --prefix)/opt/postgresql@16/bin:$PATH" PGDATA=/tmp/vapor-postgres-test
+          (brew upgrade python@3.11 || true) && (brew link --force --overwrite python@3.11 || true)
+          (brew upgrade python@3.12 || true) && (brew link --force --overwrite python@3.12 || true)
+          (brew upgrade || true)
+          brew install --overwrite postgresql@16 && brew link --overwrite --force postgresql@16
+          initdb --locale=C --auth-host scram-sha-256 -U test_username --pwfile=<(echo test_password)
+          pg_ctl start --wait
+          PGPASSWORD=test_password createdb -w -U test_username -O test_username test_database
+          PGPASSWORD=test_password psql -U test_username -w test_database <<<"ALTER SCHEMA public OWNER TO test_username;"
+      - name: Install and setup MySQL
+        run: |
+          set -x
+          brew install mysql && brew services start mysql
+          sleep 5
+          mysql -uroot --batch <<-'SQL'
+              CREATE USER test_username@localhost IDENTIFIED BY 'test_password';
+              CREATE DATABASE test_database; 
+              GRANT ALL PRIVILEGES ON test_database.* TO test_username@localhost;
+          SQL
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Run unit tests
+        env:
+          POSTGRES_HOST: 127.0.0.1
+          MYSQL_HOST: 127.0.0.1
+        run: SWIFT_DETERMINISTIC_HASHING=1 swift test --sanitize=thread --enable-code-coverage
+      - name: Upload coverage data
+        uses: vapor/swift-codecov-action@v0.3
+        with:
+          codecov_token: ${{ secrets.CODECOV_TOKEN || '' }}

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/fluent.git", from: "4.10.0"),
         .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.48.4"),
         .package(url: "https://github.com/vapor/sql-kit.git", from: "3.30.0"),
-        .package(url: "https://github.com/vapor/queues.git", from: "1.13.0"),
+        .package(url: "https://github.com/vapor/queues.git", from: "1.15.0"),
         //.package(url: "https://github.com/vapor/fluent-sqlite-driver.git", from: "4.7.1"),
         //.package(url: "https://github.com/vapor/fluent-postgres-driver.git", from: "2.9.1"),
         //.package(url: "https://github.com/vapor/fluent-mysql-driver.git", from: "4.5.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,6 @@
 // swift-tools-version:5.8
 import PackageDescription
+import class Foundation.ProcessInfo
 
 let package = Package(
     name: "QueuesFluentDriver",
@@ -16,10 +17,11 @@ let package = Package(
         .package(url: "https://github.com/vapor/sql-kit.git", from: "3.30.0"),
         .package(url: "https://github.com/vapor/queues.git", from: "1.15.0"),
         .package(url: "https://github.com/vapor/console-kit.git", from: "4.14.3"),
-        //.package(url: "https://github.com/vapor/fluent-sqlite-driver.git", from: "4.7.1"),
-        //.package(url: "https://github.com/vapor/fluent-postgres-driver.git", from: "2.9.1"),
-        //.package(url: "https://github.com/vapor/fluent-mysql-driver.git", from: "4.5.0"),
-    ],
+    ] + (ProcessInfo.processInfo.environment["CI"] != nil ? [
+        .package(url: "https://github.com/vapor/fluent-sqlite-driver.git", from: "4.7.1"),
+        .package(url: "https://github.com/vapor/fluent-postgres-driver.git", from: "2.9.1"),
+        .package(url: "https://github.com/vapor/fluent-mysql-driver.git", from: "4.5.0"),
+    ] : []),
     targets: [
         .target(
             name: "QueuesFluentDriver",
@@ -38,11 +40,12 @@ let package = Package(
             dependencies: [
                 .product(name: "XCTVapor", package: "vapor"),
                 .product(name: "ConsoleKitTerminal", package: "console-kit"),
-                //.product(name: "FluentSQLiteDriver", package: "fluent-sqlite-driver"),
-                //.product(name: "FluentPostgresDriver", package: "fluent-postgres-driver"),
-                //.product(name: "FluentMySQLDriver", package: "fluent-mysql-driver"),
                 .target(name: "QueuesFluentDriver"),
-            ],
+            ] + (ProcessInfo.processInfo.environment["CI"] != nil ? [
+                .product(name: "FluentSQLiteDriver", package: "fluent-sqlite-driver"),
+                .product(name: "FluentPostgresDriver", package: "fluent-postgres-driver"),
+                .product(name: "FluentMySQLDriver", package: "fluent-mysql-driver"),
+            ] : []),
             swiftSettings: swiftSettings
         ),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.48.4"),
         .package(url: "https://github.com/vapor/sql-kit.git", from: "3.30.0"),
         .package(url: "https://github.com/vapor/queues.git", from: "1.15.0"),
+        .package(url: "https://github.com/vapor/console-kit.git", from: "4.14.3"),
         //.package(url: "https://github.com/vapor/fluent-sqlite-driver.git", from: "4.7.1"),
         //.package(url: "https://github.com/vapor/fluent-postgres-driver.git", from: "2.9.1"),
         //.package(url: "https://github.com/vapor/fluent-mysql-driver.git", from: "4.5.0"),
@@ -36,6 +37,7 @@ let package = Package(
             name: "QueuesFluentDriverTests",
             dependencies: [
                 .product(name: "XCTVapor", package: "vapor"),
+                .product(name: "ConsoleKitTerminal", package: "console-kit"),
                 //.product(name: "FluentSQLiteDriver", package: "fluent-sqlite-driver"),
                 //.product(name: "FluentPostgresDriver", package: "fluent-postgres-driver"),
                 //.product(name: "FluentMySQLDriver", package: "fluent-mysql-driver"),

--- a/Package.swift
+++ b/Package.swift
@@ -15,9 +15,9 @@ let package = Package(
         .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.48.4"),
         .package(url: "https://github.com/vapor/sql-kit.git", from: "3.30.0"),
         .package(url: "https://github.com/vapor/queues.git", from: "1.13.0"),
-        .package(url: "https://github.com/vapor/fluent-sqlite-driver.git", from: "4.7.1"),
-        .package(url: "https://github.com/vapor/fluent-postgres-driver.git", from: "2.9.1"),
-        .package(url: "https://github.com/vapor/fluent-mysql-driver.git", from: "4.5.0"),
+        //.package(url: "https://github.com/vapor/fluent-sqlite-driver.git", from: "4.7.1"),
+        //.package(url: "https://github.com/vapor/fluent-postgres-driver.git", from: "2.9.1"),
+        //.package(url: "https://github.com/vapor/fluent-mysql-driver.git", from: "4.5.0"),
     ],
     targets: [
         .target(
@@ -36,9 +36,9 @@ let package = Package(
             name: "QueuesFluentDriverTests",
             dependencies: [
                 .product(name: "XCTVapor", package: "vapor"),
-                .product(name: "FluentSQLiteDriver", package: "fluent-sqlite-driver"),
-                .product(name: "FluentPostgresDriver", package: "fluent-postgres-driver"),
-                .product(name: "FluentMySQLDriver", package: "fluent-mysql-driver"),
+                //.product(name: "FluentSQLiteDriver", package: "fluent-sqlite-driver"),
+                //.product(name: "FluentPostgresDriver", package: "fluent-postgres-driver"),
+                //.product(name: "FluentMySQLDriver", package: "fluent-mysql-driver"),
                 .target(name: "QueuesFluentDriver"),
             ],
             swiftSettings: swiftSettings

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -1,5 +1,6 @@
 // swift-tools-version:5.9
 import PackageDescription
+import class Foundation.ProcessInfo
 
 let package = Package(
     name: "QueuesFluentDriver",
@@ -19,10 +20,11 @@ let package = Package(
         .package(url: "https://github.com/vapor/sql-kit.git", from: "3.30.0"),
         .package(url: "https://github.com/vapor/queues.git", from: "1.15.0"),
         .package(url: "https://github.com/vapor/console-kit.git", from: "4.14.3"),
-        //.package(url: "https://github.com/vapor/fluent-sqlite-driver.git", from: "4.7.1"),
-        //.package(url: "https://github.com/vapor/fluent-postgres-driver.git", from: "2.9.1"),
-        //.package(url: "https://github.com/vapor/fluent-mysql-driver.git", from: "4.5.0"),
-    ],
+    ] + (ProcessInfo.processInfo.environment["CI"] != nil ? [
+        .package(url: "https://github.com/vapor/fluent-sqlite-driver.git", from: "4.7.1"),
+        .package(url: "https://github.com/vapor/fluent-postgres-driver.git", from: "2.9.1"),
+        .package(url: "https://github.com/vapor/fluent-mysql-driver.git", from: "4.5.0"),
+    ] : []),
     targets: [
         .target(
             name: "QueuesFluentDriver",
@@ -41,11 +43,12 @@ let package = Package(
             dependencies: [
                 .product(name: "XCTVapor", package: "vapor"),
                 .product(name: "ConsoleKitTerminal", package: "console-kit"),
-                //.product(name: "FluentSQLiteDriver", package: "fluent-sqlite-driver"),
-                //.product(name: "FluentPostgresDriver", package: "fluent-postgres-driver"),
-                //.product(name: "FluentMySQLDriver", package: "fluent-mysql-driver"),
                 .target(name: "QueuesFluentDriver"),
-            ],
+            ] + (ProcessInfo.processInfo.environment["CI"] != nil ? [
+                .product(name: "FluentSQLiteDriver", package: "fluent-sqlite-driver"),
+                .product(name: "FluentPostgresDriver", package: "fluent-postgres-driver"),
+                .product(name: "FluentMySQLDriver", package: "fluent-mysql-driver"),
+            ] : []),
             swiftSettings: swiftSettings
         ),
     ]

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -17,7 +17,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/fluent.git", from: "4.10.0"),
         .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.48.4"),
         .package(url: "https://github.com/vapor/sql-kit.git", from: "3.30.0"),
-        .package(url: "https://github.com/vapor/queues.git", from: "1.13.0"),
+        .package(url: "https://github.com/vapor/queues.git", from: "1.15.0"),
         //.package(url: "https://github.com/vapor/fluent-sqlite-driver.git", from: "4.7.1"),
         //.package(url: "https://github.com/vapor/fluent-postgres-driver.git", from: "2.9.1"),
         //.package(url: "https://github.com/vapor/fluent-mysql-driver.git", from: "4.5.0"),

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -18,6 +18,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.48.4"),
         .package(url: "https://github.com/vapor/sql-kit.git", from: "3.30.0"),
         .package(url: "https://github.com/vapor/queues.git", from: "1.15.0"),
+        .package(url: "https://github.com/vapor/console-kit.git", from: "4.14.3"),
         //.package(url: "https://github.com/vapor/fluent-sqlite-driver.git", from: "4.7.1"),
         //.package(url: "https://github.com/vapor/fluent-postgres-driver.git", from: "2.9.1"),
         //.package(url: "https://github.com/vapor/fluent-mysql-driver.git", from: "4.5.0"),
@@ -39,6 +40,7 @@ let package = Package(
             name: "QueuesFluentDriverTests",
             dependencies: [
                 .product(name: "XCTVapor", package: "vapor"),
+                .product(name: "ConsoleKitTerminal", package: "console-kit"),
                 //.product(name: "FluentSQLiteDriver", package: "fluent-sqlite-driver"),
                 //.product(name: "FluentPostgresDriver", package: "fluent-postgres-driver"),
                 //.product(name: "FluentMySQLDriver", package: "fluent-mysql-driver"),

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -18,9 +18,9 @@ let package = Package(
         .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.48.4"),
         .package(url: "https://github.com/vapor/sql-kit.git", from: "3.30.0"),
         .package(url: "https://github.com/vapor/queues.git", from: "1.13.0"),
-        .package(url: "https://github.com/vapor/fluent-sqlite-driver.git", from: "4.7.1"),
-        .package(url: "https://github.com/vapor/fluent-postgres-driver.git", from: "2.9.1"),
-        .package(url: "https://github.com/vapor/fluent-mysql-driver.git", from: "4.5.0"),
+        //.package(url: "https://github.com/vapor/fluent-sqlite-driver.git", from: "4.7.1"),
+        //.package(url: "https://github.com/vapor/fluent-postgres-driver.git", from: "2.9.1"),
+        //.package(url: "https://github.com/vapor/fluent-mysql-driver.git", from: "4.5.0"),
     ],
     targets: [
         .target(
@@ -39,9 +39,9 @@ let package = Package(
             name: "QueuesFluentDriverTests",
             dependencies: [
                 .product(name: "XCTVapor", package: "vapor"),
-                .product(name: "FluentSQLiteDriver", package: "fluent-sqlite-driver"),
-                .product(name: "FluentPostgresDriver", package: "fluent-postgres-driver"),
-                .product(name: "FluentMySQLDriver", package: "fluent-mysql-driver"),
+                //.product(name: "FluentSQLiteDriver", package: "fluent-sqlite-driver"),
+                //.product(name: "FluentPostgresDriver", package: "fluent-postgres-driver"),
+                //.product(name: "FluentMySQLDriver", package: "fluent-mysql-driver"),
                 .target(name: "QueuesFluentDriver"),
             ],
             swiftSettings: swiftSettings

--- a/Sources/QueuesFluentDriver/FluentQueue.swift
+++ b/Sources/QueuesFluentDriver/FluentQueue.swift
@@ -1,10 +1,10 @@
-@preconcurrency import Queues
+import Queues
 import SQLKit
 import NIOConcurrencyHelpers
 import struct Foundation.Data
 
 /// An implementation of `Queue` which stores job data and metadata in a Fluent database.
-public struct FluentQueue: Queue, Sendable {
+public struct FluentQueue: AsyncQueue, Sendable {
     // See `Queue.context`.
     public let context: QueueContext
 
@@ -13,123 +13,115 @@ public struct FluentQueue: Queue, Sendable {
     let _sqlLockingClause: NIOLockedValueBox<(any SQLExpression)?> = .init(nil) // needs a lock for the queue to be `Sendable`
 
     // See `Queue.get(_:)`.
-    public func get(_ id: JobIdentifier) -> EventLoopFuture<JobData> {
-        self.sqlDb.select()
+    public func get(_ id: JobIdentifier) async throws -> JobData {
+        guard let job = try await self.sqlDb.select()
             .columns("payload", "max_retry_count", "queue_name", "state", "job_name", "delay_until", "queued_at", "attempts", "updated_at")
             .from(JobModel.schema)
-            .where("id", .equal, id.string)
-            .first()
-            .unwrap(or: QueuesFluentError.missingJob(id))
-            .flatMapThrowing {
-                try $0.decode(model: JobModel.self, keyDecodingStrategy: .convertFromSnakeCase)
-            }.map {
-                .init(payload: .init($0.payload), maxRetryCount: $0.maxRetryCount, jobName: $0.jobName, delayUntil: $0.delayUntil, queuedAt: $0.queuedAt)
-            }
+            .where("id", .equal, id)
+            .first(decoding: JobModel.self, keyDecodingStrategy: .convertFromSnakeCase)
+        else {
+            throw QueuesFluentError.missingJob(id)
+        }
+
+        return .init(payload: .init(job.payload), maxRetryCount: job.maxRetryCount, jobName: job.jobName, delayUntil: job.delayUntil, queuedAt: job.queuedAt)
     }
     
     // See `Queue.set(_:to:)`.
-    public func set(_ id: JobIdentifier, to jobStorage: JobData) -> EventLoopFuture<Void> {
-        self.sqlDb.eventLoop.makeFutureWithTask {
-            try await self.sqlDb.insert(into: JobModel.schema)
-                .columns("id", "queue_name", "job_name", "queued_at", "delay_until", "state", "max_retry_count", "attempts", "payload", "updated_at")
-                .values(
-                    SQLBind(id.string),
-                    SQLBind(self.queueName.string),
-                    SQLBind(jobStorage.jobName),
-                    SQLBind(jobStorage.queuedAt),
-                    SQLBind(jobStorage.delayUntil),
-                    SQLLiteral.string(StoredJobState.pending.rawValue),
-                    SQLBind(jobStorage.maxRetryCount),
-                    SQLBind(jobStorage.attempts),
-                    SQLBind(Data(jobStorage.payload)),
-                    .now()
-                )
-                // .model(JobModel(id: id, queue: self.queueName, jobData: jobStorage), keyEncodingStrategy: .convertToSnakeCase) // because enums!
-                .run()
-        }
+    public func set(_ id: JobIdentifier, to jobStorage: JobData) async throws {
+        try await self.sqlDb.insert(into: JobModel.schema)
+            .columns("id", "queue_name", "job_name", "queued_at", "delay_until", "state", "max_retry_count", "attempts", "payload", "updated_at")
+            .values(
+                .bind(id),
+                .bind(self.queueName),
+                .bind(jobStorage.jobName),
+                .bind(jobStorage.queuedAt),
+                .bind(jobStorage.delayUntil),
+                .literal(StoredJobState.pending),
+                .bind(jobStorage.maxRetryCount),
+                .bind(jobStorage.attempts),
+                .bind(Data(jobStorage.payload)),
+                .now()
+            )
+            // .model(JobModel(id: id, queue: self.queueName, jobData: jobStorage), keyEncodingStrategy: .convertToSnakeCase) // because enums!
+            .run()
     }
     
     // See `Queue.clear(_:)`.
-    public func clear(_ id: JobIdentifier) -> EventLoopFuture<Void> {
-        self.get(id).flatMap { _ in
-            self.sqlDb.delete(from: JobModel.schema)
-                .where("id", .equal, id.string)
-                .run()
-        }
+    public func clear(_ id: JobIdentifier) async throws {
+        try await self.sqlDb.delete(from: JobModel.schema)
+            .where("id", .equal, id)
+            .run()
     }
     
     // See `Queue.push(_:)`.
-    public func push(_ id: JobIdentifier) -> EventLoopFuture<Void> {
-        self.sqlDb
-            .update(JobModel.schema)
-            .set("state", to: SQLLiteral.string(StoredJobState.pending.rawValue))
+    public func push(_ id: JobIdentifier) async throws {
+        try await self.sqlDb.update(JobModel.schema)
+            .set("state", to: .literal(StoredJobState.pending))
             .set("updated_at", to: .now())
-            .where("id", .equal, id.string)
+            .where("id", .equal, id)
             .run()
     }
     
     // See `Queue.pop()`.
-    public func pop() -> EventLoopFuture<JobIdentifier?> {
-        self.sqlDb.eventLoop.makeFutureWithTask {
-            // Special case: For MySQL < 8.0, we can't use `SKIP LOCKED`. This is a really hackneyed solution,
-            // but we need to execute a database query to get the version information, `makeQueue(with:)`
-            // is purely synchronous, and `SQLDatabase.version` is not implemented in MySQLKit at the time
-            // of this writing.
-            if self._sqlLockingClause.withLockedValue({ $0 }) == nil {
-                switch self.sqlDb.dialect.name {
-                case "mysql":
-                    let version = try await self.sqlDb.select()
-                        .column(SQLFunction("version"), as: "version")
-                        .first(decodingColumn: "version", as: String.self) ?? "" // always returns one row
-                    // This is a really lazy check and it knows it; we know MySQLNIO doesn't support versions older than 5.x.
-                    if version.starts(with: "5.") || !(version.first?.isNumber ?? false) {
-                        self._sqlLockingClause.withLockedValue { $0 = SQLLockingClause.update }
-                    } else {
-                        fallthrough
-                    }
-                default:
-                    self._sqlLockingClause.withLockedValue { $0 = SQLLockingClauseWithSkipLocked.updateSkippingLocked }
+    public func pop() async throws -> JobIdentifier? {
+        // Special case: For MySQL < 8.0, we can't use `SKIP LOCKED`. This is a really hackneyed solution,
+        // but we need to execute a database query to get the version information, `makeQueue(with:)`
+        // is purely synchronous, and `SQLDatabase.version` is not implemented in MySQLKit at the time
+        // of this writing.
+        if self._sqlLockingClause.withLockedValue({ $0 }) == nil {
+            switch self.sqlDb.dialect.name {
+            case "mysql":
+                let version = try await self.sqlDb.select()
+                    .column(.function("version"), as: "version")
+                    .first(decodingColumn: "version", as: String.self)! // always returns one row
+                // This is a really lazy check and it knows it; we know MySQLNIO doesn't support versions older than 5.x.
+                if version.starts(with: "5.") || !(version.first?.isNumber ?? false) {
+                    self._sqlLockingClause.withLockedValue { $0 = SQLLockingClause.update }
+                } else {
+                    fallthrough
                 }
+            default:
+                self._sqlLockingClause.withLockedValue { $0 = SQLLockingClauseWithSkipLocked.updateSkippingLocked }
             }
+        }
 
-            let select = self.sqlDb
-                .select()
-                .column("id")
-                .from(JobModel.schema)
-                .where("state", .equal, SQLLiteral.string(StoredJobState.pending.rawValue))
-                .where("queue_name", .equal, self.queueName.string)
-                .where(.dateValue(.function("coalesce", SQLColumn("delay_until"), SQLNow())), .lessThanOrEqual, .now())
-                .orderBy("delay_until")
-                .limit(1)
-                .lockingClause(self._sqlLockingClause.withLockedValue { $0! }) // we've always set it by the time we get here
-                .query
-            
-            if self.sqlDb.dialect.supportsReturning {
-                return try await self.sqlDb.update(JobModel.schema)
-                    .set("state", to: SQLLiteral.string(StoredJobState.processing.rawValue))
-                    .set("updated_at", to: .now())
-                    .where("id", .equal, .group(select))
-                    .returning("id")
+        let select = SQLSubquery.select { $0
+            .column("id")
+            .from(JobModel.schema)
+            .where("state", .equal, .literal(StoredJobState.pending))
+            .where("queue_name", .equal, self.queueName)
+            .where(.dateValue(.function("coalesce", .column("delay_until"), SQLNow())), .lessThanOrEqual, .now())
+            .orderBy("delay_until")
+            .orderBy("queued_at")
+            .limit(1)
+            .lockingClause(self._sqlLockingClause.withLockedValue { $0! }) // we've always set it by the time we get here
+        }
+
+        if self.sqlDb.dialect.supportsReturning {
+            return try await self.sqlDb.update(JobModel.schema)
+                .set("state", to: .literal(StoredJobState.processing))
+                .set("updated_at", to: .now())
+                .where("id", .equal, select)
+                .returning("id")
+                .first(decodingColumn: "id", as: String.self)
+                .map(JobIdentifier.init(string:))
+        } else {
+            return try await self.sqlDb.transaction { transaction in
+                guard let id = try await transaction.raw("\(select)") // using raw() to make sure we run on the transaction connection
                     .first(decodingColumn: "id", as: String.self)
-                    .map(JobIdentifier.init(string:))
-            } else {
-                return try await self.sqlDb.transaction { transaction in
-                    guard let id = try await transaction.raw("\(select)") // using raw() to make sure we run on the transaction connection
-                        .first(decodingColumn: "id", as: String.self)
-                    else {
-                        return nil
-                    }
-
-                    try await transaction
-                        .update(JobModel.schema)
-                        .set("state", to: SQLLiteral.string(StoredJobState.processing.rawValue))
-                        .set("updated_at", to: .now())
-                        .where("id", .equal, id)
-                        .where("state", .equal, SQLLiteral.string(StoredJobState.pending.rawValue))
-                        .run()
-                    
-                    return JobIdentifier(string: id)
+                else {
+                    return nil
                 }
+
+                try await transaction
+                    .update(JobModel.schema)
+                    .set("state", to: .literal(StoredJobState.processing))
+                    .set("updated_at", to: .now())
+                    .where("id", .equal, id)
+                    .where("state", .equal, .literal(StoredJobState.pending))
+                    .run()
+
+                return JobIdentifier(string: id)
             }
         }
     }

--- a/Sources/QueuesFluentDriver/FluentQueue.swift
+++ b/Sources/QueuesFluentDriver/FluentQueue.swift
@@ -54,7 +54,6 @@ public struct FluentQueue: Queue, Sendable {
         self.get(id).flatMap { _ in
             self.sqlDb.delete(from: JobModel.schema)
                 .where("id", .equal, id.string)
-                .where("state", .notEqual, SQLLiteral.string(StoredJobState.completed.rawValue))
                 .run()
         }
     }

--- a/Sources/QueuesFluentDriver/FluentQueuesDriver.swift
+++ b/Sources/QueuesFluentDriver/FluentQueuesDriver.swift
@@ -3,6 +3,7 @@ import struct Fluent.DatabaseID
 import protocol SQLKit.SQLDatabase
 import protocol Queues.QueuesDriver
 import protocol Queues.Queue
+import protocol Queues.AsyncQueue
 import struct Queues.QueueContext
 import struct Queues.JobIdentifier
 import struct Queues.JobData
@@ -35,13 +36,13 @@ public struct FluentQueuesDriver: QueuesDriver {
     public func shutdown() {}
 }
 
-/*private*/ struct FailingQueue: Queue {
+/*private*/ struct FailingQueue: AsyncQueue {
     let failure: any Error
     let context: QueueContext
 
-    func get(_: JobIdentifier) -> EventLoopFuture<JobData>           { self.eventLoop.future(error: self.failure) }
-    func set(_: JobIdentifier, to: JobData) -> EventLoopFuture<Void> { self.eventLoop.future(error: self.failure) }
-    func clear(_: JobIdentifier) -> EventLoopFuture<Void>            { self.eventLoop.future(error: self.failure) }
-    func push(_: JobIdentifier) -> EventLoopFuture<Void>             { self.eventLoop.future(error: self.failure) }
-    func pop() -> EventLoopFuture<JobIdentifier?>                    { self.eventLoop.future(error: self.failure) }
+    func get(_: JobIdentifier) async throws -> JobData   { throw self.failure }
+    func set(_: JobIdentifier, to: JobData) async throws { throw self.failure }
+    func clear(_: JobIdentifier) async throws            { throw self.failure }
+    func push(_: JobIdentifier) async throws             { throw self.failure }
+    func pop() async throws -> JobIdentifier?            { throw self.failure }
 }

--- a/Sources/QueuesFluentDriver/JobModel.swift
+++ b/Sources/QueuesFluentDriver/JobModel.swift
@@ -4,16 +4,13 @@ import struct Queues.JobData
 import struct Queues.JobIdentifier
 import struct Queues.QueueName
 
-/// The various states of a job currently stored in the database.
+/// The state of a job currently stored in the database.
 enum StoredJobState: String, Codable, CaseIterable {
     /// Job is ready to be picked up for execution.
     case pending
     
     /// Job is in progress.
     case processing
-    
-    /// Job has finished, whether successfully or not.
-    case completed
 }
 
 /// Encapsulates a job's metadata and `JobData`.

--- a/Sources/QueuesFluentDriver/JobModelMigrate.swift
+++ b/Sources/QueuesFluentDriver/JobModelMigrate.swift
@@ -15,7 +15,6 @@ public struct JobModelMigration: AsyncSQLMigration {
             try await database.create(enum: stateEnumType)
                 .value("pending")
                 .value("processing")
-                .value("completed")
                 .run()
         case .inline:
             stateEnumType = "enum('\(StoredJobState.allCases.map(\.rawValue).joined(separator: "','"))')"
@@ -27,7 +26,7 @@ public struct JobModelMigration: AsyncSQLMigration {
             .column("id",              type: .text,                          .primaryKey(autoIncrement: false))
             .column("queue_name",      type: .text,                          .notNull)
             .column("job_name",        type: .text,                          .notNull)
-            .column("queued_at",       type: .timestamp,   .notNull)
+            .column("queued_at",       type: .timestamp,                     .notNull)
             .column("delay_until",     type: .timestamp)
             .column("state",           type: .custom(SQLRaw(stateEnumType)), .notNull)
             .column("max_retry_count", type: .int,                           .notNull)

--- a/Sources/QueuesFluentDriver/QueuesFluentError.swift
+++ b/Sources/QueuesFluentDriver/QueuesFluentError.swift
@@ -1,4 +1,4 @@
-@preconcurrency import struct Queues.JobIdentifier
+import struct Queues.JobIdentifier
 
 enum QueuesFluentError: Error {
     /// The queues system attempted to act on a job identifier which could not be found.

--- a/Sources/QueuesFluentDriver/QueuesTypes+Codable.swift
+++ b/Sources/QueuesFluentDriver/QueuesTypes+Codable.swift
@@ -1,0 +1,24 @@
+import struct Queues.JobIdentifier
+import struct Queues.QueueName
+
+extension Queues.JobIdentifier: Swift.Codable {
+    public init(from decoder: any Decoder) throws {
+        self.init(string: try decoder.singleValueContainer().decode(String.self))
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.string)
+    }
+}
+
+extension Queues.QueueName: Swift.Codable {
+    public init(from decoder: any Decoder) throws {
+        self.init(string: try decoder.singleValueContainer().decode(String.self))
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.string)
+    }
+}

--- a/Sources/QueuesFluentDriver/SQLKit+Convenience.swift
+++ b/Sources/QueuesFluentDriver/SQLKit+Convenience.swift
@@ -77,6 +77,28 @@ extension SQLExpression {
     static func function(_ name: String, _ args: any SQLExpression...) -> Self where Self == SQLFunction { .init(name, args: args) }
     
     static func group(_ expr: some SQLExpression) -> Self where Self == SQLGroupExpression { .init(expr) }
+
+    static func identifier(_ str: some StringProtocol) -> Self where Self == SQLIdentifier { .init(String(str)) }
+
+    static func column(_ name: some StringProtocol) -> Self where Self == SQLColumn { .init(String(name)) }
+    static func column(_ name: some StringProtocol, table: some StringProtocol) -> Self where Self == SQLColumn { .init(String(name), table: String(table)) }
+    static func column(_ name: some StringProtocol, table: some SQLExpression) -> Self where Self == SQLColumn { .column(.identifier(name), table: table) }
+    static func column(_ name: some SQLExpression, table: some StringProtocol) -> Self where Self == SQLColumn { .column(name, table: .identifier(table)) }
+    static func column(_ name: some SQLExpression, table: (any SQLExpression)? = nil)  -> Self where Self == SQLColumn { .init(name, table: table) }
+
+    static func bind(_ value: some Encodable & Sendable) -> Self where Self == SQLBind { .init(value) }
+
+    static func literal(_ val: some RawRepresentable<String>) -> Self where Self == SQLLiteral { .literal(val.rawValue) }
+    static func literal(_ str: some StringProtocol) -> Self where Self == SQLLiteral { .string(String(str)) }
+    static func literal(_ str: (some StringProtocol)?) -> Self where Self == SQLLiteral {  str.map { .string(String($0)) } ?? .null }
+    static func literal(_ int: some FixedWidthInteger) -> Self where Self == SQLLiteral { .numeric("\(int)") }
+    static func literal(_ int: (some FixedWidthInteger)?) -> Self where Self == SQLLiteral {  int.map { .numeric("\($0)") } ?? .null }
+    static func literal(_ real: some BinaryFloatingPoint) -> Self where Self == SQLLiteral { .numeric("\(real)") }
+    static func literal(_ real: (some BinaryFloatingPoint)?) -> Self where Self == SQLLiteral {  real.map { .numeric("\($0)") } ?? .null }
+    static func literal(_ bool: Bool) -> Self where Self == SQLLiteral { .boolean(bool) }
+    static func literal(_ bool: Bool?) -> Self where Self == SQLLiteral {  bool.map { .boolean($0) } ?? .null }
+
+    static func null() -> Self where Self == SQLLiteral { .null }
 }
 
 /// The following extension allows using `Database's` `transaction(_:)` wrapper with an `SQLDatabase`.

--- a/Tests/QueuesFluentDriverTests/QueuesFluentDriverTests.swift
+++ b/Tests/QueuesFluentDriverTests/QueuesFluentDriverTests.swift
@@ -28,11 +28,11 @@ final class QueuesFluentDriverTests: XCTestCase {
 
         #if canImport(FluentPostgresDriver)
         app.databases.use(DatabaseConfigurationFactory.postgres(configuration: .init(
-            hostname: Environment.get("DATABASE_HOST") ?? "localhost",
-            port: Environment.get("DATABASE_PORT").flatMap(Int.init(_:)) ?? SQLPostgresConfiguration.ianaPortNumber,
-            username: Environment.get("DATABASE_USERNAME") ?? "test_username",
-            password: Environment.get("DATABASE_PASSWORD") ?? "test_password",
-            database: Environment.get("DATABASE_NAME") ?? "test_database",
+            hostname: env("POSTGRES_HOST")     ?? env("DATABASE_HOST")     ?? "localhost",
+            port:     (env("POSTGRES_PORT")    ?? env("DATABASE_PORT")).flatMap(Int.init(_:)) ?? SQLPostgresConfiguration.ianaPortNumber,
+            username: env("POSTGRES_USERNAME") ?? env("DATABASE_USERNAME") ?? "test_username",
+            password: env("POSTGRES_PASSWORD") ?? env("DATABASE_PASSWORD") ?? "test_password",
+            database: env("POSTGRES_NAME")     ?? env("DATABASE_NAME")     ?? "test_database",
             tls: .prefer(try .init(configuration: .clientDefault)))
         ), as: .psql)
         #endif
@@ -41,11 +41,11 @@ final class QueuesFluentDriverTests: XCTestCase {
         var config = TLSConfiguration.clientDefault
         config.certificateVerification = .none
         app.databases.use(DatabaseConfigurationFactory.mysql(configuration: .init(
-            hostname: Environment.get("DATABASE_HOST") ?? "localhost",
-            port: Environment.get("DATABASE_PORT").flatMap(Int.init(_:)) ?? MySQLConfiguration.ianaPortNumber,
-            username: Environment.get("DATABASE_USERNAME") ?? "test_username",
-            password: Environment.get("DATABASE_PASSWORD") ?? "test_password",
-            database: Environment.get("DATABASE_NAME") ?? "test_database",
+            hostname: env("MYSQL_HOST")     ?? env("DATABASE_HOST")     ?? "localhost",
+            port:     (env("MYSQL_PORT")    ?? env("DATABASE_PORT")).flatMap(Int.init(_:)) ?? MySQLConfiguration.ianaPortNumber,
+            username: env("MYSQL_USERNAME") ?? env("DATABASE_USERNAME") ?? "test_username",
+            password: env("MYSQL_PASSWORD") ?? env("DATABASE_PASSWORD") ?? "test_password",
+            database: env("MYSQL_NAME")     ?? env("DATABASE_NAME")     ?? "test_database",
             tlsConfiguration: config
         )), as: .mysql)
         #endif
@@ -277,7 +277,7 @@ func XCTAssertNotNilAsync(
 }
 
 func env(_ name: String) -> String? {
-    return ProcessInfo.processInfo.environment[name]
+    ProcessInfo.processInfo.environment[name]
 }
 
 let isLoggingConfigured: Bool = {

--- a/Tests/QueuesFluentDriverTests/QueuesFluentDriverTests.swift
+++ b/Tests/QueuesFluentDriverTests/QueuesFluentDriverTests.swift
@@ -3,8 +3,9 @@ import XCTVapor
 import FluentKit
 import Logging
 import SQLKit
+import ConsoleKitTerminal
 @testable import QueuesFluentDriver
-@preconcurrency import Queues
+import Queues
 #if canImport(FluentSQLiteDriver)
 import FluentSQLiteDriver
 #endif
@@ -17,13 +18,14 @@ import FluentMySQLDriver
 import NIOSSL
 
 final class QueuesFluentDriverTests: XCTestCase {
-    var dbid: DatabaseID { .init(string: "sqlite") }
     var app: Application!
-    
+    var dbid: DatabaseID!
+
     private func useDbs(_ app: Application) throws {
         #if canImport(FluentSQLiteDriver)
         app.databases.use(.sqlite(.memory), as: .sqlite)
         #endif
+
         #if canImport(FluentPostgresDriver)
         app.databases.use(DatabaseConfigurationFactory.postgres(configuration: .init(
             hostname: Environment.get("DATABASE_HOST") ?? "localhost",
@@ -34,6 +36,7 @@ final class QueuesFluentDriverTests: XCTestCase {
             tls: .prefer(try .init(configuration: .clientDefault)))
         ), as: .psql)
         #endif
+
         #if canImport(FluentMySQLDriver)
         var config = TLSConfiguration.clientDefault
         config.certificateVerification = .none
@@ -47,146 +50,189 @@ final class QueuesFluentDriverTests: XCTestCase {
         )), as: .mysql)
         #endif
     }
-    
-    func testApplication() async throws {
-        self.app.migrations.add(JobModelMigration(), to: self.dbid)
-        
+
+    private func withEachDatabase(_ closure: () async throws -> Void) async throws {
+        func run(_ dbid: DatabaseID) async throws {
+            self.dbid = dbid
+            self.app = try await Application.make(.testing)
+            self.app.logger[metadataKey: "test-dbid"] = "\(dbid.string)"
+
+            try self.useDbs(self.app)
+            self.app.migrations.add(JobModelMigration(), to: self.dbid)
+            self.app.queues.use(.fluent(self.dbid))
+
+            try await self.app.autoMigrate()
+
+            do { try await closure() }
+            catch {
+                try? await self.app.autoRevert()
+                try? await self.app.asyncShutdown()
+                throw error
+            }
+
+            try await self.app.autoRevert()
+            try await self.app.asyncShutdown()
+            self.app = nil
+        }
+
+        #if canImport(FluentSQLiteDriver)
+        try await run(.sqlite)
+        #endif
+
+        #if canImport(FluentPostgresDriver)
+        try await run(.psql)
+        #endif
+
+        #if canImport(FluentMySQLDriver)
+        try await run(.mysql)
+        #endif
+    }
+
+    func testApplication() async throws { try await self.withEachDatabase {
         let email = Email()
+
         self.app.queues.add(email)
-
-        self.app.queues.use(.fluent(self.dbid))
-        
-        try await self.app.autoMigrate()
-
         self.app.get("send-email") { req in
-            req.queue.dispatch(Email.self, .init(to: "tanner@vapor.codes"))
-                .map { HTTPStatus.ok }
+            try await req.queue.dispatch(Email.self, .init(to: "gwynne@vapor.codes"))
+            return HTTPStatus.ok
         }
 
         try await self.app.testable().test(.GET, "send-email") { res async in
             XCTAssertEqual(res.status, .ok)
         }
-        
-        XCTAssertEqual(email.sent, [])
+
+        await XCTAssertEqualAsync(await email.sent, [])
         try await self.app.queues.queue.worker.run().get()
-        XCTAssertEqual(email.sent, [.init(to: "tanner@vapor.codes")])
-        
-        try await self.app.autoRevert()
-    }
-    
-    func testFailedJobLoss() async throws {
-        self.app.queues.add(FailingJob())
-        self.app.queues.use(.fluent(self.dbid))
-        self.app.migrations.add(JobModelMigration(), to: self.dbid)
-        try await self.app.autoMigrate()
+        await XCTAssertEqualAsync(await email.sent, [.init(to: "gwynne@vapor.codes")])
+    } }
 
+    func testFailedJobLoss() async throws { try await self.withEachDatabase {
         let jobId = JobIdentifier()
-        self.app.get("test") { req in
-            req.queue.dispatch(FailingJob.self, ["foo": "bar"], id: jobId)
-                .map { HTTPStatus.ok }
-        }
 
+        self.app.queues.add(FailingJob())
+        self.app.get("test") { req in
+            try await req.queue.dispatch(FailingJob.self, ["foo": "bar"], id: jobId)
+            return HTTPStatus.ok
+        }
         try await self.app.testable().test(.GET, "test") { res async in
             XCTAssertEqual(res.status, .ok)
         }
-        
         await XCTAssertThrowsErrorAsync(try await self.app.queues.queue.worker.run().get()) {
             XCTAssert($0 is FailingJob.Failure)
         }
-        
-        await XCTAssertNotNilAsync(try await (self.app.databases.database(self.dbid, logger: .init(label: ""), on: self.app.eventLoopGroup.any())! as! any SQLDatabase)
-            .select().columns("*").from(JobModel.schema).where("id", .equal, jobId.string).first())
-            
-        try await self.app.autoRevert()
-    }
-    
-    func testDelayedJobIsRemovedFromProcessingQueue() async throws {
-        self.app.queues.add(DelayedJob())
+        await XCTAssertNotNilAsync(
+            try await (self.app.db(self.dbid) as! any SQLDatabase).select()
+                .columns("*")
+                .from(JobModel.schema)
+                .where("id", .equal, jobId)
+                .first()
+        )
+    } }
 
-        self.app.queues.use(.fluent(self.dbid))
-
-        self.app.migrations.add(JobModelMigration(), to: self.dbid)
-        try await self.app.autoMigrate()
-
+    func testDelayedJobIsRemovedFromProcessingQueue() async throws { try await self.withEachDatabase {
         let jobId = JobIdentifier()
-        self.app.get("delay-job") { req in
-            req.queue.dispatch(DelayedJob.self, .init(name: "vapor"),
-                               delayUntil: Date().addingTimeInterval(3600),
-                               id: jobId)
-                .map { HTTPStatus.ok }
-        }
 
+        self.app.queues.add(DelayedJob())
+        self.app.get("delay-job") { req in
+            try await req.queue.dispatch(DelayedJob.self, .init(name: "vapor"), delayUntil: .init(timeIntervalSinceNow: 3600.0), id: jobId)
+            return HTTPStatus.ok
+        }
         try await self.app.testable().test(.GET, "delay-job") { res async in
             XCTAssertEqual(res.status, .ok)
         }
         
-        await XCTAssertEqualAsync(try await (self.app.databases.database(self.dbid, logger: .init(label: ""), on: self.app.eventLoopGroup.any())! as! any SQLDatabase)
-            .select().columns("*").from(JobModel.schema).where("id", .equal, jobId.string)
-            .first(decoding: JobModel.self, keyDecodingStrategy: .convertFromSnakeCase)?.state, .pending)
-        
-        try await self.app.autoRevert()
-    }
-    
-    func testCoverageForFailingQueue() {
+        await XCTAssertEqualAsync(
+            try await (self.app.db(self.dbid) as! any SQLDatabase).select()
+                .columns("*")
+                .from(JobModel.schema)
+                .where("id", .equal, jobId)
+                .first(decoding: JobModel.self, keyDecodingStrategy: .convertFromSnakeCase)?.state,
+            .pending
+        )
+    } }
+
+    func testCoverageForFailingQueue() async throws {
+        self.app = try await Application.make(.testing)
         let queue = FailingQueue(
             failure: QueuesFluentError.unsupportedDatabase,
-            context: .init(queueName: .init(string: ""), configuration: .init(), application: self.app, logger: .init(label: ""), on: self.app.eventLoopGroup.any())
+            context: .init(queueName: .default, configuration: .init(), application: self.app, logger: self.app.logger, on: self.app.eventLoopGroup.any())
         )
-        XCTAssertThrowsError(try queue.get(.init()).wait())
-        XCTAssertThrowsError(try queue.set(.init(), to: JobData(payload: [], maxRetryCount: 0, jobName: "", delayUntil: nil, queuedAt: .init())).wait())
-        XCTAssertThrowsError(try queue.clear(.init()).wait())
-        XCTAssertThrowsError(try queue.push(.init()).wait())
-        XCTAssertThrowsError(try queue.pop().wait())
-    }
-    
-    override func setUp() async throws {
-        XCTAssert(isLoggingConfigured)
-        
-        self.app = try await Application.make(.testing)
-        try self.useDbs(self.app)
-    }
-    
-    override func tearDown() async throws {
+        await XCTAssertThrowsErrorAsync(try await queue.get(.init()))
+        await XCTAssertThrowsErrorAsync(try await queue.set(.init(), to: JobData(payload: [], maxRetryCount: 0, jobName: "", delayUntil: nil, queuedAt: .init())))
+        await XCTAssertThrowsErrorAsync(try await queue.clear(.init()))
+        await XCTAssertThrowsErrorAsync(try await queue.push(.init()))
+        await XCTAssertThrowsErrorAsync(try await queue.pop())
         try await self.app.asyncShutdown()
         self.app = nil
     }
+
+    func testSQLKitUtilities() async throws { try await self.withEachDatabase {
+        func serialized(_ expr: some SQLExpression) -> String {
+            var serializer = SQLSerializer(database: self.app.db(self.dbid) as! any SQLDatabase)
+            expr.serialize(to: &serializer)
+            return serializer.sql
+        }
+        XCTAssertEqual(serialized(.group(.identifier("a"))), "(\(serialized(.identifier("a"))))")
+        XCTAssertEqual(serialized(.column("a", table: "a")), "\(serialized(.identifier("a"))).\(serialized(.identifier("a")))")
+        XCTAssertEqual(serialized(.column("a", table: .identifier("a"))), "\(serialized(.identifier("a"))).\(serialized(.identifier("a")))")
+        XCTAssertEqual(serialized(.column(.identifier("a"), table: "a")), "\(serialized(.identifier("a"))).\(serialized(.identifier("a")))")
+        XCTAssertEqual(serialized(.column(.identifier("a"), table: .identifier("a"))), "\(serialized(.identifier("a"))).\(serialized(.identifier("a")))")
+        XCTAssertEqual(serialized(.literal(String?("a"))), "\(serialized(.literal("a")))")
+        XCTAssertEqual(serialized(.literal(String?.none)), "NULL")
+        XCTAssertEqual(serialized(.literal(1)), "1")
+        XCTAssertEqual(serialized(.literal(Int?(1))), "1")
+        XCTAssertEqual(serialized(.literal(Int?.none)), "NULL")
+        XCTAssertEqual(serialized(.literal(1.0)), "1.0")
+        XCTAssertEqual(serialized(.literal(Double?(1.0))), "1.0")
+        XCTAssertEqual(serialized(.literal(Double?.none)), "NULL")
+        XCTAssertEqual(serialized(.literal(true)), "\(serialized(SQLLiteral.boolean(true)))")
+        XCTAssertEqual(serialized(.literal(Bool?(true))), "\(serialized(SQLLiteral.boolean(true)))")
+        XCTAssertEqual(serialized(.literal(Bool?.none)), "NULL")
+        XCTAssertEqual(serialized(.null()), "NULL")
+
+        await XCTAssertNotNilAsync(try await (self.app.db(self.dbid) as! any SQLDatabase).transaction { $0.eventLoop.makeSucceededFuture(()) }.get())
+    } }
+
+    func testNamesCoding() throws {
+        XCTAssertEqual(JobIdentifier(string: "a"), try JSONDecoder().decode(JobIdentifier.self, from: Data(#""a""#.utf8)))
+        XCTAssertEqual(String(decoding: try JSONEncoder().encode(JobIdentifier(string: "a")), as: UTF8.self), #""a""#)
+        XCTAssertEqual(QueueName(string: "a").string, try JSONDecoder().decode(QueueName.self, from: Data(#""a""#.utf8)).string)
+        XCTAssertEqual(String(decoding: try JSONEncoder().encode(QueueName(string: "a")), as: UTF8.self), #""a""#)
+    }
+
+    override class func setUp() {
+        XCTAssert(isLoggingConfigured)
+    }
 }
 
-final class Email: Job {
+actor Email: AsyncJob {
     struct Message: Codable, Equatable {
         let to: String
     }
     
     var sent: [Message] = []
     
-    func dequeue(_ context: QueueContext, _ message: Message) -> EventLoopFuture<Void> {
+    func dequeue(_ context: QueueContext, _ message: Message) async throws {
         self.sent.append(message)
-        context.logger.info("sending email \(message)")
-        return context.eventLoop.makeSucceededFuture(())
+        context.logger.info("sending email", metadata: ["message": "\(message)"])
     }
 }
 
-final class DelayedJob: Job {
+struct DelayedJob: AsyncJob {
     struct Message: Codable, Equatable {
         let name: String
     }
     
-    func dequeue(_ context: QueueContext, _ message: Message) -> EventLoopFuture<Void> {
-        context.logger.info("Hello \(message.name)")
-        return context.eventLoop.makeSucceededFuture(())
+    func dequeue(_ context: QueueContext, _ message: Message) async throws {
+        context.logger.info("Hello", metadata: ["name": "\(message.name)"])
     }
 }
 
-struct FailingJob: Job {
+struct FailingJob: AsyncJob {
     struct Failure: Error {}
     
-    func dequeue(_ context: QueueContext, _ message: [String: String]) -> EventLoopFuture<Void> {
-        context.eventLoop.makeFailedFuture(Failure())
-    }
-    
-    func error(_ context: QueueContext, _ error: any Error, _ payload: [String: String]) -> EventLoopFuture<Void> {
-        context.eventLoop.makeFailedFuture(Failure())
-    }
+    func dequeue(_ context: QueueContext, _ message: [String: String]) async throws { throw Failure() }
+    func error(_ context: QueueContext, _ error: any Error, _ payload: [String: String]) async throws { throw Failure() }
 }
 
 func XCTAssertEqualAsync<T>(
@@ -235,10 +281,10 @@ func env(_ name: String) -> String? {
 }
 
 let isLoggingConfigured: Bool = {
-    LoggingSystem.bootstrap { label in
-        var handler = StreamLogHandler.standardOutput(label: label)
-        handler.logLevel = env("LOG_LEVEL").flatMap { .init(rawValue: $0) } ?? .info
-        return handler
-    }
+    LoggingSystem.bootstrap(
+        fragment: timestampDefaultLoggerFragment(),
+        console: Terminal(),
+        level: env("LOG_LEVEL").flatMap { .init(rawValue: $0) } ?? .info
+    )
     return true
 }()


### PR DESCRIPTION
Changes:

- Adopters of this package are no longer forced to have all three of the Fluent SQL database driver stacks (SQLite, Postgres, MySQL) in their dependencies (although SwiftPM usually manages to avoid this problem on its own); the tests instead will only use whichever drivers were included at the time of the tests being built (defaults to none).
- `StoredJobState.completed` has been removed, since we never actually used it. This helpfully improves the behavior of the `clear()` query.
- The queue driver now adopts the new `AsyncQueue` protocol and no longer has to go back and forth between futures.
- The tests are now more comprehensive.
- Fixed another `Sendable` warning.