### PR TITLE
Fix race condition between set() and push()

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,9 +57,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - macos-version: macos-13
-            xcode-version: '~15.2'
           - macos-version: macos-14
+            xcode-version: latest-stable
+          - macos-version: macos-15
             xcode-version: latest-stable
     runs-on: ${{ matrix.macos-version }}
     timeout-minutes: 60

--- a/Sources/QueuesFluentDriver/FluentQueue.swift
+++ b/Sources/QueuesFluentDriver/FluentQueue.swift
@@ -38,7 +38,7 @@ public struct FluentQueue: AsyncQueue, Sendable {
                 .bind(jobStorage.jobName),
                 .bind(jobStorage.queuedAt),
                 .bind(jobStorage.delayUntil),
-                .literal(StoredJobState.pending),
+                .literal(StoredJobState.initial),
                 .bind(jobStorage.maxRetryCount),
                 .bind(jobStorage.attempts),
                 .bind(Data(jobStorage.payload)),

--- a/Sources/QueuesFluentDriver/JobModel.swift
+++ b/Sources/QueuesFluentDriver/JobModel.swift
@@ -6,6 +6,9 @@ import struct Queues.QueueName
 
 /// The state of a job currently stored in the database.
 enum StoredJobState: String, Codable, CaseIterable {
+    /// Job has been set up but is not yet ready to execute.
+    case initial
+    
     /// Job is ready to be picked up for execution.
     case pending
     


### PR DESCRIPTION
A worker can end up picking up a job between `set()` and `push()`, causing a race condition that results in the job running twice. This PR fixes the race by adding an `initial` state for jobs that haven't yet been pushed.

There is no test included because I couldn't work out a clean way to reliably test for the race.

Fixes #13.

Thanks to @sterien7 for reporting, and to @sidepelican for the excellent analysis of the problem in the [original bug report](https://github.com/m-barthelemy/vapor-queues-fluent-driver/issues/27) against the old version of the driver!