### PR TITLE
Fix jobs being retried forever

### DIFF
--- a/Sources/QueuesFluentDriver/FluentQueue.swift
+++ b/Sources/QueuesFluentDriver/FluentQueue.swift
@@ -25,7 +25,7 @@ public struct FluentQueue: AsyncQueue, Sendable {
             throw QueuesFluentError.missingJob(id)
         }
 
-        return .init(payload: .init(job.payload), maxRetryCount: job.maxRetryCount, jobName: job.jobName, delayUntil: job.delayUntil, queuedAt: job.queuedAt)
+        return .init(payload: .init(job.payload), maxRetryCount: job.maxRetryCount, jobName: job.jobName, delayUntil: job.delayUntil, queuedAt: job.queuedAt, attempts: job.attempts)
     }
     
     // See `Queue.set(_:to:)`.


### PR DESCRIPTION
Currently, if a job is dispatched with a non-zero maxRetryCount, the job is retried forever. This is because the `JobData` was initialised with the default value (0) for `attempts`.

I’ve added a test for this, however it is currently flakey (especially when run with SQLite) since `delayUntil` is set for retried jobs, even if the retry delay is zero. This can be fixed by changing the behaviour in the queues package to set a nil `delayUntil` when the retry delay is zero, but I’m not sure if this is the best solution.