### PR TITLE
Fix SQLite with delayed jobs

### DIFF
--- a/Sources/QueuesFluentDriver/FluentQueue.swift
+++ b/Sources/QueuesFluentDriver/FluentQueue.swift
@@ -99,7 +99,7 @@ public struct FluentQueue: AsyncQueue, Sendable {
             .from(self.jobsTable)
             .where("state", .equal, .literal(StoredJobState.pending))
             .where("queue_name", .equal, self.queueName)
-            .where(.dateValue(.function("coalesce", .column("delay_until"), SQLNow())), .lessThanOrEqual, .now())
+            .where(.function("coalesce", .column("delay_until"), .now()), .lessThanOrEqual, .now())
             .orderBy("delay_until")
             .orderBy("queued_at")
             .limit(1)


### PR DESCRIPTION
Currently, jobs with a value for `delay_until` are never run when using SQLite as the underlying database. This is because one of the conditions used to select a job is `unixepoch(coalesce("delay_until",  'now')) <= unixepoch('now')`. This is fine if `delay_until` is NULL, since it will be equivalent to `unixepoch('now') <= unixepoch('now')` which is always true. However, if `delay_until` has a value, the condition becomes equivalent to `unixepoch("delay_until") <= unixepoch('now')` which is incorrect since `delay_until` is already stored as an epoch timestamp. Passing a epoch timestamp to `unixepoch` results in NULL.