### PR TITLE
Fix creation of the database enum when using a non-default space

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,15 +34,14 @@ jobs:
     runs-on: ubuntu-latest
     container: ${{ matrix.swift-image }}
     services:
-      psql: { image: 'postgres:16', env: { POSTGRES_USER: test_username, POSTGRES_PASSWORD: test_password, POSTGRES_DB: test_database, POSTGRES_HOST_AUTH_METHOD: scram-sha-256, POSTGRES_INITDB_ARGS: --auth-host=scram-sha-256 } }
-      mysql: { image: 'mysql:8', env: { MYSQL_ALLOW_EMPTY_PASSWORD: true, MYSQL_USER: test_username, MYSQL_PASSWORD: test_password, MYSQL_DATABASE: test_database } }
+      psql: { image: 'postgres:17', env: { POSTGRES_USER: test_username, POSTGRES_PASSWORD: test_password, POSTGRES_DB: test_database, POSTGRES_HOST_AUTH_METHOD: scram-sha-256, POSTGRES_INITDB_ARGS: --auth-host=scram-sha-256 } }
+      mysql: { image: 'mysql:9', env: { MYSQL_ALLOW_EMPTY_PASSWORD: true, MYSQL_USER: test_username, MYSQL_PASSWORD: test_password, MYSQL_DATABASE: test_database } }
     timeout-minutes: 60
     steps:
       - name: Check out code
         uses: actions/checkout@v4
       - name: Run unit tests
         env:
-          SANITIZE: ${{ matrix.sanitize }}
           POSTGRES_HOST: psql
           MYSQL_HOST: mysql
         run: SWIFT_DETERMINISTIC_HASHING=1 swift test --sanitize=thread --enable-code-coverage

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,5 @@
 // swift-tools-version:5.9
 import PackageDescription
-import class Foundation.ProcessInfo
 
 let package = Package(
     name: "QueuesFluentDriver",
@@ -14,16 +13,16 @@ let package = Package(
         .library(name: "QueuesFluentDriver", targets: ["QueuesFluentDriver"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.100.0"),
-        .package(url: "https://github.com/vapor/fluent.git", from: "4.10.0"),
-        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.48.4"),
-        .package(url: "https://github.com/vapor/sql-kit.git", from: "3.30.0"),
-        .package(url: "https://github.com/vapor/queues.git", from: "1.15.0"),
-        .package(url: "https://github.com/vapor/console-kit.git", from: "4.14.3"),
-    ] + (ProcessInfo.processInfo.environment["CI"] != nil ? [
-        .package(url: "https://github.com/vapor/fluent-sqlite-driver.git", from: "4.7.1"),
-        .package(url: "https://github.com/vapor/fluent-postgres-driver.git", from: "2.9.1"),
-        .package(url: "https://github.com/vapor/fluent-mysql-driver.git", from: "4.5.0"),
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.106.0"),
+        .package(url: "https://github.com/vapor/fluent.git", from: "4.12.0"),
+        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.49.0"),
+        .package(url: "https://github.com/vapor/sql-kit.git", from: "3.32.0"),
+        .package(url: "https://github.com/vapor/queues.git", from: "1.16.1"),
+        .package(url: "https://github.com/vapor/console-kit.git", from: "4.15.0"),
+    ] + (Context.environment["CI"] != nil ? [
+        .package(url: "https://github.com/vapor/fluent-sqlite-driver.git", from: "4.8.0"),
+        .package(url: "https://github.com/vapor/fluent-postgres-driver.git", from: "2.10.0"),
+        .package(url: "https://github.com/vapor/fluent-mysql-driver.git", from: "4.7.0"),
     ] : []),
     targets: [
         .target(
@@ -44,7 +43,7 @@ let package = Package(
                 .product(name: "XCTVapor", package: "vapor"),
                 .product(name: "ConsoleKitTerminal", package: "console-kit"),
                 .target(name: "QueuesFluentDriver"),
-            ] + (ProcessInfo.processInfo.environment["CI"] != nil ? [
+            ] + (Context.environment["CI"] != nil ? [
                 .product(name: "FluentSQLiteDriver", package: "fluent-sqlite-driver"),
                 .product(name: "FluentPostgresDriver", package: "fluent-postgres-driver"),
                 .product(name: "FluentMySQLDriver", package: "fluent-mysql-driver"),

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A driver for [Queues]. Uses [Fluent] to store job metadata in an SQL database.
 
 ## Compatibility
 
-This package makes use of the `SKIP LOCKED` feature supported by some of the major database engines (most notably [PostgresSQL][postgres-skip-locked] and [MySQL][mysql-skip-locked]) when available to make a best-effort guarantee that a task or job won't be picked by multiple workers.
+This package makes use of the `SKIP LOCKED` feature supported by some of the major database engines (most notably [PostgresSQL][postgres-skip-locked] and [MySQL][mysql-skip-locked]) when available to make a best-effort guarantee that a job won't be picked up by multiple workers.
 
 This package should be compatible with any SQL database supported by the various Fluent drivers. It is specifically known to work with:
 
@@ -26,16 +26,16 @@ This package should be compatible with any SQL database supported by the various
 
 #### Adding the dependency
 
-Add `QueuesFluentDriver` as dependency to your `Package.swift`:
+Add `QueuesFluentDriver` to your `Package.swift` as a dependency:
 
 ```swift
   dependencies: [
-    .package(url: "https://github.com/vapor-community/vapor-queues-fluent-driver.git", from: "3.0.0-beta.4"),
+    .package(url: "https://github.com/vapor-community/vapor-queues-fluent-driver.git", from: "3.0.0"),
     ...
   ]
 ```
 
-Add `QueuesFluentDriver` to the target you want to use it in:
+Then add `QueuesFluentDriver` to the target you want to use it in:
 ```swift
   targets: [
     .target(name: "MyFancyTarget", dependencies: [
@@ -44,9 +44,16 @@ Add `QueuesFluentDriver` to the target you want to use it in:
   ]
 ```
 
+Or use SwiftPM's dependency management commands:
+
+```
+swift package add-dependency 'https://github.com/vapor-community/vapor-queues-fluent-driver.git' --from '3.0.0'
+swift package add-target-dependency --package vapor-queues-fluent-driver QueuesFluentDriver MyFancyTarget
+```
+
 #### Configuration
 
-This package includes a migration to create the database table which holds job metadata; add it to your Fluent configuration as you would any other migration:
+This package includes a migration to create the database table which holds job metadata. Add it to your Fluent configuration as you would any other migration:
 
 ```swift
 app.migrations.add(JobModelMigration())
@@ -57,14 +64,15 @@ Finally, load the `QueuesFluentDriver` driver:
 app.queues.use(.fluent())
 ```
 
-> [!WARNING]
-> Always call `app.databases.use(...)` **before** calling `app.queues.use(.fluent())`!
-
 ## Options
 
-### Using a custom Database 
+The `.fluent()` driver method accepts several configuration options.
 
-You can optionally create a dedicated non-default `Database` with a custom `DatabaseID` for use with your queues, as in the following example:
+### Using a custom DatabaseID
+
+The driver may be configured with a `DatabaseID` other than the default to use for queue operations. The default of `nil` corresponds to Fluent's default database. The database ID must be registered with `app.databases.use(...)` _before_ configuring the Queues driver.
+
+Example:
 
 ```swift
 extension DatabaseID {
@@ -72,16 +80,47 @@ extension DatabaseID {
 }
 
 func configure(_ app: Application) async throws {
-    app.databases.use(.postgres(configuration: ...), as: .queues, isDefault: false)
+    app.databases.use(.postgres(configuration: ...), as: .queues)
     app.queues.use(.fluent(.queues))
 }
 ```
+
+### Preserving records of completed jobs
+
+By default, once a job has finished, it is removed entirely from the jobs table in the database. Setting the `preserveCompletedJobs` parameter to `true` configures the driver to leave finished jobs in the jobs table, with a state of `completed`.
+
+Example:
+
+```swift
+func configure(_ app: Application) async throws {
+    app.queues.use(.fluent(preserveCompletedJobs: true))
+}
+```
+
+> [!NOTE]
+> The driver never removes jobs in the `completed` state from the table, even if `preserveCompletedJobs` is later turned off. "Cleaning up" completed jobs must be done manually, with a query such as `DELETE FROM _jobs_meta WHERE state='completed'`.
+
+### Changing the name and location of the jobs table
+
+By default, the jobs table is created in the default space (e.g. the current schema - usually `public` - in PostgreSQL, or the current database in MySQL and SQLite) and has the name `_jobs_meta`. The table name and space may be configured, using the `jobsTableName` and `jobsTableSpace` parameters respectively. If the `JobModelMigration` is in use (recommended), the same name and space must be passed to both its initializer and the driver for the migration to work correctly.
+
+Example:
+
+```swift
+func configure(_ app: Application) async throws {
+    app.migrations.add(JobModelMigration(jobsTableName: "_my_jobs", jobsTableSpace: "not_public"))
+    app.queues.use(.fluent(jobsTableName: "_my_jobs", jobsTableSpace: "not_public"))
+}
+```
+
+> [!NOTE]
+> When the `JobModelMigration` is used with PostgreSQL, the table name is used as a prefix for the enumeration type created to represent job states in the database, and the enumeration type is created in the same space as the table.
 
 ## Caveats
 
 ### Polling interval and number of workers
 
-By default, the Vapor Queues system starts 2 workers per available CPU core, with each worker would polling the database once per second. On a 4-core system, this would results in 8 workers querying the database every second. Most configurations do not need this many workers. Additionally, when using SQLite as the underlying database it is generally inadvisable to run more than one worker at a time, as SQLite does not have the .
+By default, the Vapor Queues system starts 2 workers per available CPU core, with each worker would polling the database once per second. On a 4-core system, this would results in 8 workers querying the database every second. Most configurations do not need this many workers. Additionally, when using SQLite as the underlying database it is generally inadvisable to run more than one worker at a time, as SQLite does not have the necessary support for locking to make this safe.
 
 The polling interval can be changed using the `refreshInterval` configuration setting:
 

--- a/Sources/QueuesFluentDriver/JobModelMigrate.swift
+++ b/Sources/QueuesFluentDriver/JobModelMigrate.swift
@@ -1,34 +1,37 @@
 import SQLKit
 
 public struct JobModelMigration: AsyncSQLMigration {
-    private let jobsTableString: String
     private let jobsTable: SQLQualifiedTable
+    private let jobsTableIndexName: String
+    private let stateEnumType: SQLQualifiedTable // "table" is a bit of a misnomer here, but the expression still does the right thing
+    private let oldStateEnumName: String?
 
     /// Public initializer.
     public init(
         jobsTableName: String = "_jobs_meta",
         jobsTableSpace: String? = nil
     ) {
-        self.jobsTableString = "\(jobsTableSpace.map { "\($0)_" } ?? "")\(jobsTableName)"
-        self.jobsTable = .init(jobsTableName, space: jobsTableSpace)
+        self.jobsTable = SQLQualifiedTable(jobsTableName, space: jobsTableSpace)
+        self.jobsTableIndexName = "i_\(jobsTableName)_state_queue_delayuntil"
+        self.stateEnumType = SQLQualifiedTable("\(jobsTableName)_storedjobstatus", space: jobsTableSpace)
+        self.oldStateEnumName = jobsTableSpace.map { "\($0)_\(jobsTableName)_storedjobstatus" }
     }
 
     // See `AsyncSQLMigration.prepare(on:)`.
     public func prepare(on database: any SQLDatabase) async throws {
-        let stateEnumType: any SQLExpression
+        let actualStateEnumType: SQLDataType
 
         switch database.dialect.enumSyntax {
         case .typeName:
-            stateEnumType = .identifier("\(self.jobsTableString)_storedjobstatus")
-            var builder = database.create(enum: stateEnumType)
+            var builder = database.create(enum: self.stateEnumType)
             builder = StoredJobState.allCases.reduce(builder, { $0.value($1.rawValue) })
             try await builder.run()
+            actualStateEnumType = .custom(self.stateEnumType)
         case .inline:
-             // This is technically a misuse of SQLFunction, but it produces the correct syntax
-            stateEnumType = .function("enum", StoredJobState.allCases.map { .literal($0.rawValue) })
+            actualStateEnumType = .custom(SQLEnumDataType(cases: StoredJobState.allCases.map { .literal($0.rawValue) }))
         default:
             // This is technically a misuse of SQLFunction, but it produces the correct syntax
-            stateEnumType = .function("varchar", .literal(16))
+            actualStateEnumType = .custom(.function("varchar", .literal(16)))
         }
 
         /// This whole pile of nonsense is only here because of
@@ -46,18 +49,18 @@ public struct JobModelMigration: AsyncSQLMigration {
         }
 
         try await database.create(table: self.jobsTable)
-            .column("id",              type: .text,                  .primaryKey(autoIncrement: false))
-            .column("queue_name",      type: .text,                  .notNull)
-            .column("job_name",        type: .text,                  .notNull)
-            .column("queued_at",       type: manualTimestampType,    .notNull)
-            .column("delay_until",     type: manualTimestampType,    .default(SQLLiteral.null))
-            .column("state",           type: .custom(stateEnumType), .notNull)
-            .column("max_retry_count", type: .int,                   .notNull)
-            .column("attempts",        type: .int,                   .notNull)
-            .column("payload",         type: .blob,                  .notNull)
-            .column("updated_at",      type: .timestamp,             autoTimestampConstraints)
+            .column("id",              type: .text,               .primaryKey(autoIncrement: false))
+            .column("queue_name",      type: .text,               .notNull)
+            .column("job_name",        type: .text,               .notNull)
+            .column("queued_at",       type: manualTimestampType, .notNull)
+            .column("delay_until",     type: manualTimestampType, .default(SQLLiteral.null))
+            .column("state",           type: actualStateEnumType, .notNull)
+            .column("max_retry_count", type: .int,                .notNull)
+            .column("attempts",        type: .int,                .notNull)
+            .column("payload",         type: .blob,               .notNull)
+            .column("updated_at",      type: .timestamp,          autoTimestampConstraints)
             .run()
-        try await database.create(index: "i_\(self.jobsTableString)_state_queue_delayUntil")
+        try await database.create(index: self.jobsTableIndexName)
             .on(self.jobsTable)
             .column("state")
             .column("queue_name")
@@ -68,9 +71,17 @@ public struct JobModelMigration: AsyncSQLMigration {
     // See `AsyncSQLMigration.revert(on:)`.
     public func revert(on database: any SQLDatabase) async throws {
         try await database.drop(table: self.jobsTable).run()
+
         switch database.dialect.enumSyntax {
         case .typeName:
-            try await database.drop(enum: "\(self.jobsTableString)_storedjobstatus").run()
+            // In version 3.0.1 and earlier of the driver, if a space was specified, the enum's name was different,
+            // and the enum ended up in the default space rather than the one given. For compatibility, we need to drop
+            // the old name from the default space. Fortunately, `DROP TYPE` supports `IF EXISTS`.
+            if let oldStateEnumName = self.oldStateEnumName {
+                try await database.drop(enum: oldStateEnumName).ifExists().run()
+            }
+
+            try await database.drop(enum: self.stateEnumType).ifExists().run()
         default:
             break
         }

--- a/Sources/QueuesFluentDriver/SQLKit+Convenience.swift
+++ b/Sources/QueuesFluentDriver/SQLKit+Convenience.swift
@@ -68,13 +68,15 @@ enum SQLLockingClauseWithSkipLocked: SQLExpression {
 
 /// These overloads allow specifying various commonly-used `SQLExpression`s using more concise syntax. For example,
 /// `.bind("hello")` rather than `SQLBind("hello")`, `.group(expr)` rather than `SQLGroupExpression(expr)`, etc.
+/// This is a small portion extracted from a much more robust SQLKit utility library, which can be found at
+/// https://gist.github.com/gwynne/9bc9d04d44cf53dca529b526b7736324
 
 extension SQLExpression {
     static func dateValue<E: SQLExpression>(_ value: E) -> Self where Self == SQLDateValue<E> { .init(value) }
     
     static func now() -> Self where Self == SQLDateValue<SQLNow> { .now() }
 
-    static func function(_ name: String, _ args: any SQLExpression...) -> Self where Self == SQLFunction { .init(name, args: args) }
+    static func function(_ name: String, _ args: any SQLExpression...) -> Self where Self == SQLFunction { .function(name, args) }
     static func function(_ name: String, _ args: [any SQLExpression]) -> Self where Self == SQLFunction { .init(name, args: args) }
     
     static func group(_ expr: some SQLExpression) -> Self where Self == SQLGroupExpression { .init(expr) }

--- a/Tests/QueuesFluentDriverTests/QueuesFluentDriverTests.swift
+++ b/Tests/QueuesFluentDriverTests/QueuesFluentDriverTests.swift
@@ -266,6 +266,15 @@ final class QueuesFluentDriverTests: XCTestCase {
         XCTAssertEqual(model.attempts, 0)
         XCTAssertEqual(model.payload, Data())
         XCTAssertNotNil(model.updatedAt)
+
+        let contrivedJobDataRaw = #"{"payload":[],"maxRetryCount":0,"queuedAt":0,"jobName":""}"#
+        let contrivedJobData = try! JSONDecoder().decode(JobData.self, from: Data(contrivedJobDataRaw.utf8))
+
+        XCTAssertNil(contrivedJobData.attempts)
+
+        let contrivedModel = JobModel(id: .init(string: ""), queue: .init(string: ""), jobData: contrivedJobData)
+
+        XCTAssertEqual(contrivedModel.attempts, 0)
     }
 
     func testSQLKitUtilities() async throws { try await self.withEachDatabase {


### PR DESCRIPTION
Previously, if a non-`nil` `jobsTableSpace` was provided to the `JobModelMigration` when using PostgreSQL, the job state enum type was incorrectly created in the default schema instead of alongside the jobs table. This is now fixed, and the name of the space is no longer used to prefix the names of the enumeration or the index on the table. The migration's `revert(_:)` method will attempt to drop the old name from the default space (using `IF EXISTS`) in order to maintain compatibility.

Additional changes:

- `Package.swift` no longer imports `Foundation` to get at the current environment (I learned that `Context.environment` exists).
- The minimum version requirements for the dependencies have been bumped.
- The CI has been updated to include tests against the latest PostgreSQL and MySQL versions.
- A number of issues in the README have been fixed and information on the driver's configurable options has been added.