### PR TITLE
Add migration to support users of old versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,9 +27,9 @@ jobs:
       fail-fast: false
       matrix:
         swift-image:
-          - swift:5.9-jammy
           - swift:5.10-noble
           - swift:6.0-noble
+          - swift:6.1-noble
           - swiftlang/swift:nightly-main-jammy
     runs-on: ubuntu-latest
     container: ${{ matrix.swift-image }}
@@ -99,3 +99,15 @@ jobs:
         uses: vapor/swift-codecov-action@v0.3
         with:
           codecov_token: ${{ secrets.CODECOV_TOKEN || '' }}
+
+  musl:
+    runs-on: ubuntu-latest
+    container: swift:6.1-noble
+    timeout-minutes: 30
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Install SDK
+        run: swift sdk install https://download.swift.org/swift-6.1-release/static-sdk/swift-6.1-RELEASE/swift-6.1-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz --checksum 111c6f7d280a651208b8c74c0521dd99365d785c1976a6e23162f55f65379ac6
+      - name: Build
+        run: swift build --swift-sdk x86_64-swift-linux-musl

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 import PackageDescription
 
 let package = Package(
@@ -58,5 +58,6 @@ var swiftSettings: [SwiftSetting] { [
     .enableUpcomingFeature("ExistentialAny"),
     .enableUpcomingFeature("ConciseMagicFile"),
     .enableUpcomingFeature("DisableOutwardActorInference"),
+    .enableUpcomingFeature("MemberImportVisibility"),
     .enableExperimentalFeature("StrictConcurrency=complete"),
 ] }

--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ This package includes a migration to create the database table which holds job m
 app.migrations.add(JobModelMigration())
 ```
 
+If you were previously a user of the 1.x or 2.x releases of this driver and have an existing job metadata table in the old data format, you can use `JobModelOldFormatMigration` instead to transparently upgrade the old table to the new format:
+
+```swift
+app.migrations.add(JobModelOldFormatMigration())
+```
+
+> [!IMPORTANT]
+> Use only one or the other of the two migrations; do _not_ use both, and do not change which one you use once one of them has been run.
+
 Finally, load the `QueuesFluentDriver` driver:
 ```swift    
 app.queues.use(.fluent())
@@ -102,19 +111,22 @@ func configure(_ app: Application) async throws {
 
 ### Changing the name and location of the jobs table
 
-By default, the jobs table is created in the default space (e.g. the current schema - usually `public` - in PostgreSQL, or the current database in MySQL and SQLite) and has the name `_jobs_meta`. The table name and space may be configured, using the `jobsTableName` and `jobsTableSpace` parameters respectively. If the `JobModelMigration` is in use (recommended), the same name and space must be passed to both its initializer and the driver for the migration to work correctly.
+By default, the jobs table is created in the default space (e.g. the current schema - usually `public` - in PostgreSQL, or the current database in MySQL and SQLite) and has the name `_jobs_meta`. The table name and space may be configured, using the `jobsTableName` and `jobsTableSpace` parameters respectively. If `JobModelMigration` or `JobModelOldFormatMigration` are in use (as is recommended), the same name and space must be passed to both its initializer and the driver for the migration to work correctly.
 
 Example:
 
 ```swift
 func configure(_ app: Application) async throws {
     app.migrations.add(JobModelMigration(jobsTableName: "_my_jobs", jobsTableSpace: "not_public"))
+    // OR
+    app.migrations.add(JobModelOldFormatMigration(jobsTableName: "_my_jobs", jobsTableSpace: "not_public"))
+    
     app.queues.use(.fluent(jobsTableName: "_my_jobs", jobsTableSpace: "not_public"))
 }
 ```
 
 > [!NOTE]
-> When the `JobModelMigration` is used with PostgreSQL, the table name is used as a prefix for the enumeration type created to represent job states in the database, and the enumeration type is created in the same space as the table.
+> When `JobModelMigration` or `JobModelOldFormatMigration` are used with PostgreSQL, the table name is used as a prefix for the enumeration type created to represent job states in the database, and the enumeration type is created in the same space as the table.
 
 ## Caveats
 

--- a/Sources/QueuesFluentDriver/Documentation.docc/Documentation.md
+++ b/Sources/QueuesFluentDriver/Documentation.docc/Documentation.md
@@ -62,6 +62,14 @@ This package includes a migration to create the database table which holds job m
 app.migrations.add(JobModelMigration())
 ```
 
+If you were previously a user of the 1.x or 2.x releases of this driver and have an existing job metadata table in the old data format, you can use `JobModelOldFormatMigration` instead to transparently upgrade the old table to the new format:
+
+```swift
+app.migrations.add(JobModelOldFormatMigration())
+```
+
+> Important: Use only one or the other of the two migrations; do _not_ use both, and do not change which one you use once one of them has been run.
+
 Finally, load the `QueuesFluentDriver` driver:
 ```swift    
 app.queues.use(.fluent())
@@ -104,18 +112,21 @@ func configure(_ app: Application) async throws {
 
 ### Changing the name and location of the jobs table
 
-By default, the jobs table is created in the default space (e.g. the current schema - usually `public` - in PostgreSQL, or the current database in MySQL and SQLite) and has the name `_jobs_meta`. The table name and space may be configured, using the `jobsTableName` and `jobsTableSpace` parameters respectively. If the `JobModelMigration` is in use (recommended), the same name and space must be passed to both its initializer and the driver for the migration to work correctly.
+By default, the jobs table is created in the default space (e.g. the current schema - usually `public` - in PostgreSQL, or the current database in MySQL and SQLite) and has the name `_jobs_meta`. The table name and space may be configured, using the `jobsTableName` and `jobsTableSpace` parameters respectively. If `JobModelMigration` or `JobModelOldFormatMigration` are in use (as is recommended), the same name and space must be passed to both its initializer and the driver for the migration to work correctly.
 
 Example:
 
 ```swift
 func configure(_ app: Application) async throws {
     app.migrations.add(JobModelMigration(jobsTableName: "_my_jobs", jobsTableSpace: "not_public"))
+    // OR
+    app.migrations.add(JobModelOldFormatMigration(jobsTableName: "_my_jobs", jobsTableSpace: "not_public"))
+    
     app.queues.use(.fluent(jobsTableName: "_my_jobs", jobsTableSpace: "not_public"))
 }
 ```
 
-> Note: When the `JobModelMigration` is used with PostgreSQL, the table name is used as a prefix for the enumeration type created to represent job states in the database, and the enumeration type is created in the same space as the table.
+> Note: When `JobModelMigration` or `JobModelOldFormatMigration` are used with PostgreSQL, the table name is used as a prefix for the enumeration type created to represent job states in the database, and the enumeration type is created in the same space as the table.
 
 ## Caveats
 

--- a/Sources/QueuesFluentDriver/JobModelMigrate.swift
+++ b/Sources/QueuesFluentDriver/JobModelMigrate.swift
@@ -1,4 +1,5 @@
 import SQLKit
+import FluentKit
 
 public struct JobModelMigration: AsyncSQLMigration {
     private let jobsTable: SQLQualifiedTable

--- a/Sources/QueuesFluentDriver/JobModelMigrate.swift
+++ b/Sources/QueuesFluentDriver/JobModelMigrate.swift
@@ -1,6 +1,9 @@
 import SQLKit
 import FluentKit
 
+/// A migration to create the job metadata table and any associated objects, such as enumeration types and indexes.
+///
+/// This migration is guaranteed to be compatible with MySQL 5.7+, PostgreSQL, and SQLite.
 public struct JobModelMigration: AsyncSQLMigration {
     private let jobsTable: SQLQualifiedTable
     private let jobsTableIndexName: String

--- a/Sources/QueuesFluentDriver/JobModelOldFormatMigration.swift
+++ b/Sources/QueuesFluentDriver/JobModelOldFormatMigration.swift
@@ -1,0 +1,120 @@
+import FluentKit
+import Logging
+import SQLKit
+
+/// A migration to upgrade the data from the old 1.x and 2.x versions of this driver to the current version.
+///
+/// This migration is compatible with all known released versions of the driver. It is _not_ compatible with any
+/// of the 3.x-beta tags. It is known to be compatible with MySQL 8.0+, PostgreSQL 11+, and SQLite 3.38.0+, and to be
+/// _incompatible_ with MySQL 5.7 and earlier.
+///
+/// Once run, this migration is not reversible. See discussion in ``JobModelOldFormatMigration/revert(on:)-3xv3q`` for
+/// more details. This migration should be used **_in place of_** ``JobModelMigration``, not in addition to it. Using
+/// both migrations will cause database errors. If an error occurs during migration, a reasonable attempt is made to
+/// restore everything to its original state. Even under extreme conditions, the original data is guaranteed to remain
+/// intact until the migration is succesfully completed; the original data is never modified, and is deleted only after
+/// everything has finished without errors.
+///
+/// > Note: The `payload` format used by the MySQL-specific logic is a bit bizarre; instead of the plain binary string
+/// > used for the other databases, MySQL's version is Base64-encoded and double-quoted. This is an artifact of the
+/// > missing conformance of `Data` to `MySQLDataConvertible` in `MySQLNIO`, a bug that cannot be fixed at the present
+/// > time without causing problematic behavioral changes.
+public struct JobModelOldFormatMigration: AsyncSQLMigration {
+    private let jobsTableName: String
+    private let jobsTableSpace: String?
+
+    /// Public initializer.
+    public init(
+        jobsTableName: String = "_jobs_meta",
+        jobsTableSpace: String? = nil
+    ) {
+        self.jobsTableName = jobsTableName
+        self.jobsTableSpace = jobsTableSpace
+    }
+
+    // See `AsyncSQLMigration.prepare(on:)`.
+    public func prepare(on database: any SQLDatabase) async throws {
+        /// Return a `SQLQueryString` which extracts the field with the given name from the old-format "data" JSON as the given type.
+        func dataGet(_ name: String, as type: String) -> SQLQueryString {
+            switch database.dialect.name {
+            case "postgresql": "((convert_from(\"data\", 'UTF8')::jsonb)->>\(literal: name))::\(unsafeRaw: type == "double" ? "double precision" : type)"
+            case "mysql":      "json_value(convert(data USING utf8mb4), \(literal: "$.\(name)") RETURNING \(unsafeRaw: type == "text" ? "CHAR" : (type == "double" ? "DOUBLE" : "SIGNED")))"
+            case "sqlite":     "data->>\(literal: "$.\(name)")"
+            default: ""
+            }
+        }
+        /// Return a `SQLQueryString` which extracts the timestamp field with the given name from the old-format "data" JSON as a UNIX
+        /// timestamp, compensating for the difference between the UNIX epoch and Date's reference date (978,307,200 seconds).
+        func dataTimestamp(_ name: String) -> SQLQueryString {
+            switch database.dialect.name {
+            case "postgresql": "to_timestamp(\(dataGet(name, as: "double")) + 978307200.0)"
+            case "mysql":      "from_unixtime(\(dataGet(name, as: "double")) + 978307200.0)"
+            case "sqlite":     "\(dataGet(name, as: "double")) + 978307200.0"
+            default: ""
+            }
+        }
+        /// Return a `SQLQueryString` which extracts the payload from the old-format "data" JSON, converting the original array of one-byte
+        /// integers to the database's appropriate binary representation (`bytea` for Postgres, `BINARY` collation with Base64 encoding and
+        /// surrounding quotes for MySQL (don't ask...), `BLOB` affinity for SQLite).
+        func dataPayload() -> SQLQueryString {
+            switch database.dialect.name {
+            case "postgresql": #"coalesce((SELECT decode(string_agg(lpad(to_hex(b::int), 2, '0'), ''), 'hex') FROM jsonb_array_elements_text((convert_from("data", 'UTF8')::jsonb)->'payload') AS a(b)), '\x')"#
+            case "mysql":      #"coalesce((SELECT /*+SET_VAR(group_concat_max_len=1048576)*/ concat('"',to_base64(group_concat(char(b) SEPARATOR '')),'"') FROM json_table(convert(data USING utf8mb4), '$.payload[*]' COLUMNS (b INT PATH '$')) t), X'')"#
+            case "sqlite":     #"coalesce((SELECT unhex(group_concat(format('%02x',b.value), '')) FROM json_each(data, '$.payload') as b), '')"#
+            default: ""
+            }
+        }
+
+        // Make sure that we keep the old table in the same space when we move it aside.
+        let tempTable = SQLQualifiedTable("_temp_old_\(self.jobsTableName)", space: self.jobsTableSpace)
+        let jobsTable = SQLQualifiedTable(self.jobsTableName, space: self.jobsTableSpace)
+        let enumType = SQLQualifiedTable("\(self.jobsTableName)_storedjobstatus", space: self.jobsTableSpace)
+
+        // 1. Rename the existing table so we can create the new format in its place.
+        try await database.alter(table: jobsTable).rename(to: tempTable).run()
+
+        do {
+            // 2. Run the "real" migration to create the correct table structure and any associated objects.
+            try await JobModelMigration(jobsTableName: self.jobsTableName, jobsTableSpace: self.jobsTableSpace).prepare(on: database)
+
+            // 3. Migrate the data from the old table.
+            try await database.insert(into: jobsTable)
+                .columns("id", "queue_name", "job_name", "queued_at", "delay_until", "state", "max_retry_count", "attempts", "payload", "updated_at")
+                .select { $0
+                    .column("job_id")
+                    .column("queue")
+                    .column(.function("coalesce", dataGet("jobName", as: "text"), .literal("")))
+                    .column(.function("coalesce", dataTimestamp("queuedAt"), .identifier("created_at")))
+                    .column(dataTimestamp("delayUntil"))
+                    .column(database.dialect.name == "postgresql" ? "state::\(enumType)" as SQLQueryString : "state")
+                    .column(.function("coalesce", dataGet("maxRetryCount", as: "bigint"), .literal(0)))
+                    .column(.function("coalesce", dataGet("attempts", as: "bigint"), .literal(0)))
+                    .column(dataPayload())
+                    .column("updated_at")
+                    .from(tempTable)
+                }
+                .run()
+        } catch {
+            // Attempt to clean up after ourselves by deleting the new table and moving the old one back into place.
+            try? await database.drop(table: jobsTable).run()
+            try? await database.alter(table: tempTable).rename(to: jobsTable).run()
+            throw error
+        }
+
+        // 4. Drop the old table.
+        try await database.drop(table: tempTable).run()
+    }
+
+    // See `AsyncSQLMigration.revert(on:)`.
+    public func revert(on database: any SQLDatabase) async throws {
+        /// This migration technically can be reverted, if one is willing to consider the values of the original
+        /// `id`, `created_at`, and `deleted_at` columns spurious, and therefore disposable. However, it would be
+        /// a good deal of work - in particular, turning the binary payload back into a JSON byte array would
+        /// even more involved than the frontways conversion, and the utility of doing so is insufficient to
+        /// justify the effort unless this feature ends up being commonly requested. We could call through to
+        /// ``JobModelMigration``'s revert, but it seems best to err on the side of caution for this migration.
+
+        // TODO: Should we throw an error instead of logging an easily-missed message?
+        database.logger.warning("Reverting the \(self.name) migration is not implemented; your job metadata table is unchanged!")
+    }
+}

--- a/Sources/QueuesFluentDriver/SQLKit+Convenience.swift
+++ b/Sources/QueuesFluentDriver/SQLKit+Convenience.swift
@@ -112,7 +112,7 @@ extension SQLDatabase {
         return fluentSelf.transaction { fluentTransaction in closure(fluentTransaction as! any SQLDatabase) }
     }
 
-    func transaction<T>(_ closure: @escaping @Sendable (any SQLDatabase) async throws -> T) async throws -> T {
+    func transaction<T: Sendable>(_ closure: @escaping @Sendable (any SQLDatabase) async throws -> T) async throws -> T {
         guard let fluentSelf = self as? any Database else { fatalError("Cannot use `SQLDatabase.transaction(_:)` on a non-Fluent database.") }
         
         return try await fluentSelf.transaction { fluentTransaction in try await closure(fluentTransaction as! any SQLDatabase) }
@@ -148,5 +148,12 @@ extension AsyncSQLMigration {
     
     public func revert(on database: any Database) async throws {
         try await self.revert(on: database as! any SQLDatabase)
+    }
+}
+
+/// This extension covers a gap in the `SQLAlterTableBuilder` API.
+extension SQLDatabase {
+    func alter(table: some SQLExpression) -> SQLAlterTableBuilder {
+        .init(.init(name: table), on: self)
     }
 }

--- a/Tests/QueuesFluentDriverTests/QueuesFluentDriverTests.swift
+++ b/Tests/QueuesFluentDriverTests/QueuesFluentDriverTests.swift
@@ -65,27 +65,35 @@ final class QueuesFluentDriverTests: XCTestCase {
         #endif
     }
 
-    private func withEachDatabase(preserveJobs: Bool = false, tableName: String = "_jobs_meta", _ closure: () async throws -> Void) async throws {
+    private func withEachDatabase(preserveJobs: Bool = false, tableName: String? = "_jobs_meta", _ closure: () async throws -> Void) async throws {
         func run(_ dbid: DatabaseID, defaultSpace: String? = nil) async throws {
             self.dbid = dbid
             self.app = try await Application.make(.testing)
             self.app.logger[metadataKey: "test-dbid"] = "\(dbid.string)"
 
             try self.useDBs(self.app)
-            self.app.migrations.add(JobModelMigration(jobsTableName: tableName, jobsTableSpace: defaultSpace), to: self.dbid)
-            self.app.queues.use(.fluent(self.dbid, preservesCompletedJobs: preserveJobs, jobsTableName: tableName, jobsTableSpace: defaultSpace))
+            if let tableName {
+                self.app.migrations.add(JobModelMigration(jobsTableName: tableName, jobsTableSpace: defaultSpace), to: self.dbid)
+                self.app.queues.use(.fluent(self.dbid, preservesCompletedJobs: preserveJobs, jobsTableName: tableName, jobsTableSpace: defaultSpace))
+            }
 
-            try await self.app.autoMigrate()
+            if tableName != nil {
+                try await self.app.autoMigrate()
+            }
 
             do { try await closure() }
             catch {
-                try? await self.app.autoRevert()
+                if tableName != nil {
+                    try? await self.app.autoRevert()
+                }
                 try? await self.app.asyncShutdown()
                 self.app = nil
                 throw error
             }
 
-            try await self.app.autoRevert()
+            if tableName != nil {
+                try await self.app.autoRevert()
+            }
             try await self.app.asyncShutdown()
             self.app = nil
         }
@@ -236,6 +244,105 @@ final class QueuesFluentDriverTests: XCTestCase {
             1
         )
     } }
+
+    func testOldFormatMigration() async throws { try await self.withEachDatabase(tableName: nil) {
+        // N.B.: One probably notices that MySQL gets a lot of special-casing in this test. This is another instance
+        // of it; we only need this so the `SET time_zone` thing will work.
+        try await self.app.db(self.dbid).withConnection { db in
+
+        let sqlDb = db as! any SQLDatabase
+        let isMySQL = sqlDb.dialect.name == "mysql"
+
+        if isMySQL {
+            let version = try await sqlDb.select().column(.function("version"), as: "version").first(decodingColumn: "version", as: String.self)!
+            if version.starts(with: "5.") || !(version.first?.isNumber ?? false) {
+                return // This migration is known to require MySQL 8.0+
+            }
+
+            try await sqlDb.raw("SET time_zone='+00:00'").run()
+        }
+
+        // Taken from https://github.com/m-barthelemy/vapor-queues-fluent-driver/blob/2.0.0/Sources/QueuesFluentDriver/JobModelMigrate.swift
+        try await db.schema("_old_jobs_meta")
+            .id()
+            .field("job_id",     .string, .required)
+            .field("queue",      .string, .required)
+            .field("data",       .data,   .required)
+            .field("state",      .string, .required)
+            .field("created_at", .datetime)
+            .field("updated_at", .datetime)
+            .field("deleted_at", .datetime)
+            .create()
+
+        do {
+            let job1Jobid = UUID().uuidString,
+                job1DelayUntil = Date(timeIntervalSinceReferenceDate: Double(Int(Date().timeIntervalSinceReferenceDate * 1000.0)) / 1000.0 + 120.0), // avoid rounding error
+                job1QueuedAt = Date(timeIntervalSinceReferenceDate: Double(Int(Date().timeIntervalSinceReferenceDate * 1000.0)) / 1000.0), // avoid rounding error
+                job1JobData = JobData(payload: .init(#"{"hello": "world"}"#.utf8), maxRetryCount: 0, jobName: "Job 1", delayUntil: job1DelayUntil, queuedAt: job1QueuedAt),
+                job1Data = try JSONEncoder().encode(job1JobData), job1DataBind = isMySQL ? SQLBind(String(decoding: job1Data, as: UTF8.self)) : SQLBind(job1Data),
+                job2Jobid = UUID().uuidString,
+                job2QueuedAt = Date(timeIntervalSinceReferenceDate: Double(Int(Date().timeIntervalSinceReferenceDate * 1000.0)) / 1000.0), // avoid rounding error
+                job2JobData = JobData(payload: .init(#"{"world": "hello"}"#.utf8), maxRetryCount: 1, jobName: "Job 2", delayUntil: nil, queuedAt: job2QueuedAt, attempts: 0),
+                job2Data = try JSONEncoder().encode(job2JobData), job2DataBind = isMySQL ? SQLBind(String(decoding: job2Data, as: UTF8.self)) : SQLBind(job2Data)
+
+            try await sqlDb.insert(into: "_old_jobs_meta")
+                .columns("id", "job_id", "queue", "data", "state", "created_at", "updated_at", "deleted_at")
+                .values(.bind(UUID()), .bind(job1Jobid), .bind("test_queue1"), job1DataBind, .bind("processing"), .now(), .now(), .null())
+                .values(.bind(UUID()), .bind(job2Jobid), .bind("test_queue2"), job2DataBind, .bind("completed"), .now(), .now(), .now())
+                .run()
+
+            try await JobModelOldFormatMigration(jobsTableName: "_old_jobs_meta", jobsTableSpace: nil).prepare(on: db)
+
+            let count = try await sqlDb.select()
+                .column(.function("count", SQLLiteral.all), as: "count")
+                .from("_old_jobs_meta")
+                .first(decodingColumn: "count", as: Int.self)
+            XCTAssertEqual(count, 2)
+
+            let model1Maybe = try await sqlDb.select()
+                .columns("id", "queue_name", "job_name", "queued_at", "delay_until", "state", "max_retry_count", "attempts", "payload", "updated_at")
+                .from("_old_jobs_meta")
+                .where("id", .equal, .bind(job1Jobid))
+                .first(decoding: JobModel.self, keyDecodingStrategy: .convertFromSnakeCase)
+            let model1 = try XCTUnwrap(model1Maybe)
+
+            let model2Maybe = try await sqlDb.select()
+                .columns("id", "queue_name", "job_name", "queued_at", "delay_until", "state", "max_retry_count", "attempts", "payload", "updated_at")
+                .from("_old_jobs_meta")
+                .where("id", .equal, .bind(job2Jobid))
+                .first(decoding: JobModel.self, keyDecodingStrategy: .convertFromSnakeCase)
+            let model2 = try XCTUnwrap(model2Maybe)
+
+            XCTAssertEqual(model1.queueName, "test_queue1")
+            XCTAssertEqual(model1.jobName, "Job 1")
+            XCTAssertEqual(model1.queuedAt, job1QueuedAt)
+            XCTAssertEqual(model1.delayUntil, job1DelayUntil)
+            XCTAssertEqual(model1.state, .processing)
+            XCTAssertEqual(model1.maxRetryCount, 0)
+            XCTAssertEqual(model1.attempts, 0)
+            XCTAssertEqual(model1.payload, Data(job1JobData.payload), "\(String(decoding: model1.payload, as: UTF8.self)) - \(String(decoding: job1JobData.payload, as: UTF8.self))")
+            XCTAssertEqual(model2.queueName, "test_queue2")
+            XCTAssertEqual(model2.jobName, "Job 2")
+            XCTAssertEqual(model2.queuedAt, job2QueuedAt)
+            XCTAssertNil(model2.delayUntil)
+            XCTAssertEqual(model2.state, .completed)
+            XCTAssertEqual(model2.maxRetryCount, 1)
+            XCTAssertEqual(model2.attempts, 0)
+            XCTAssertEqual(model2.payload, Data(job2JobData.payload), "\(String(decoding: model2.payload, as: UTF8.self)) - \(String(decoding: job2JobData.payload, as: UTF8.self))")
+
+            try await sqlDb.drop(table: "_old_jobs_meta").ifExists().run()
+            if sqlDb.dialect.enumSyntax == .typeName {
+                try await sqlDb.drop(enum: "_old_jobs_meta_storedjobstatus").ifExists().run()
+            }
+        } catch {
+            try? await sqlDb.drop(table: "_old_jobs_meta").ifExists().run()
+            if sqlDb.dialect.enumSyntax == .typeName {
+                try? await sqlDb.drop(enum: "_old_jobs_meta_storedjobstatus").ifExists().run()
+            }
+            sqlDb.logger.error("Error", metadata: ["error": "\(String(reflecting: error))"])
+            throw error
+        }
+    } } }
 
     func testCoverageForFailingQueue() async throws {
         self.app = try await Application.make(.testing)

--- a/Tests/QueuesFluentDriverTests/QueuesFluentDriverTests.swift
+++ b/Tests/QueuesFluentDriverTests/QueuesFluentDriverTests.swift
@@ -1,11 +1,5 @@
-import XCTest
-import XCTVapor
-import FluentKit
-import Logging
-import SQLKit
 import ConsoleKitTerminal
-@testable import QueuesFluentDriver
-import Queues
+import Fluent
 #if canImport(FluentSQLiteDriver)
 import FluentSQLiteDriver
 #endif
@@ -15,7 +9,13 @@ import FluentPostgresDriver
 #if canImport(FluentMySQLDriver)
 import FluentMySQLDriver
 #endif
+import Logging
 import NIOSSL
+import Queues
+@testable import QueuesFluentDriver
+import SQLKit
+import XCTest
+import XCTVapor
 
 extension DatabaseID {
     static var mysql2: Self { .init(string: "mysql2") }


### PR DESCRIPTION
There is now a new migration, `JobModelOldFormatMigration`, which can be used in place of `JobModelMigration` by users who have an existing job metadata table from a 1.x or 2.x version of the driver. This migration will upgrade old tables to the new format without any loss of data. See the README and the comments in the code for more details.

Additional changes:
- Swift 5.10 is now the required minimum version.
- The code is now compliant with `MemberImportVisibility`.
- For MySQL users, the main migration will now use `DATETIME(6)` instead of `DATETIME` so that timestamps have subsecond precision. The `updated_at` column is now also a `DATETIME(6)` instead of a `TIMESTAMP`. Existing users do not need to make any changes to their tables or add any new migrations; the existing table layout continues to work as it did before. Only new users and users who change their tables manually will see this.
- For non-MySQL users, the `updated_at` column is now `NOT NULL`. Again, existing users do not need to take any action; everything continues to work as before.
- The CI has been updated for Swift 6.1 and now checks Linux SDK compatibility.
- A lingering `Sendable` warning has been fixed.